### PR TITLE
Add vararg support.

### DIFF
--- a/RobloxCS/CodeGenerator.cs
+++ b/RobloxCS/CodeGenerator.cs
@@ -354,7 +354,7 @@ namespace RobloxCS
             WriteLine(" do");
             _indent++;
 
-            
+
             Visit(node.Statement);
             foreach (var incrementor in node.Incrementors)
             {
@@ -589,7 +589,7 @@ namespace RobloxCS
                 Visit(node.ExpressionBody);
                 WriteLine();
             }
-            
+
             _indent--;
             Write("end");
         }
@@ -787,7 +787,7 @@ namespace RobloxCS
         {
             WriteLine('{');
             _indent++;
-            
+
             foreach (var initializer in node.Initializers)
             {
                 Visit(initializer);
@@ -1341,6 +1341,13 @@ namespace RobloxCS
 
         public override void VisitParameter(ParameterSyntax node)
         {
+            if (node.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.ParamsKeyword)))
+            {
+                Write("...");
+                if (node.Type != null)
+                    WriteTypeAnnotation(node.Type);
+                return;
+            }
             Write(GetName(node));
             if (node.Type != null)
             {
@@ -1362,12 +1369,17 @@ namespace RobloxCS
                     }
                 }
             }
+            ParameterSyntax? vaargParameter = null;
             foreach (var parameter in node.Parameters)
             {
                 Visit(parameter);
                 if (parameter != node.Parameters.Last())
                 {
                     Write(", ");
+                }
+                else
+                {
+                    if (parameter.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.ParamsKeyword))) vaargParameter = parameter;
                 }
             }
             Write(')');
@@ -1387,6 +1399,14 @@ namespace RobloxCS
                     break;
             }
             _indent++;
+
+            if (vaargParameter != null)
+            {
+                WriteLine("--> rbxcsc: vararg parameter conversion");
+                Write($"local {GetName(vaargParameter)} = {{ ... }}");
+                WriteLine();
+            }
+
 
             foreach (var parameter in node.Parameters)
             {
@@ -1795,12 +1815,12 @@ namespace RobloxCS
                 HashSet<SyntaxKind> fullyQualifiedParentKinds = [SyntaxKind.SimpleMemberAccessExpression, SyntaxKind.ObjectCreationExpression];
                 if (
                     symbol != null
-                        && symbol is ITypeSymbol typeSymbol
-                        && node.Parent != null
-                        && fullyQualifiedParentKinds.Contains(node.Parent.Kind())
-                        && typeSymbol.ContainingNamespace != null
-                        && (parentNamespace != null ? Utility.GetNamesFromNode(parentNamespace.Name).LastOrDefault() != typeSymbol.ContainingNamespace.Name : true)
-                        && !Constants.NO_FULL_QUALIFICATION_TYPES.Contains(typeSymbol.ContainingNamespace.Name)
+                    && symbol is ITypeSymbol typeSymbol
+                    && node.Parent != null
+                    && fullyQualifiedParentKinds.Contains(node.Parent.Kind())
+                    && typeSymbol.ContainingNamespace != null
+                    && (parentNamespace != null ? Utility.GetNamesFromNode(parentNamespace.Name).LastOrDefault() != typeSymbol.ContainingNamespace.Name : true)
+                    && !Constants.NO_FULL_QUALIFICATION_TYPES.Contains(typeSymbol.ContainingNamespace.Name)
                 )
                 {
                     var usings = GetUsings();


### PR DESCRIPTION
This commit adds support for vararg functions into the transcompiler via the params keyword.

```cs
// Example C# before transcompilation
public int Insanity(int s, params int[] countUp)
{
    var n = 0;
    foreach (int i in countUp)
    {
        n += i;
    }
    return n + s;
}
```

```luau
-- Post transcompilation
function self.Insanity(_, s: number, ...: { number }): number
    --> rbxcsc: vararg parameter conversion
    local countUp = { ... }
    local n = 0
    for _, i in countUp do
        n = i
    end
    return n + s
end
```

The implementation has the only downside that it will create a new table, which could result in performance issues, but it will do for now.