### PR TITLE
Bitwise operations codegen warning.

### DIFF
--- a/RobloxCS/CodeGenerator.cs
+++ b/RobloxCS/CodeGenerator.cs
@@ -723,6 +723,14 @@ namespace RobloxCS
                 Write(", ");
                 Visit(node.Right);
                 Write(")");
+
+                if ((leftType == null || rightType == null) || (!Constants.UNSUPPORTED_BITWISE_TYPES.Contains(leftType.Name) && !Constants.UNSUPPORTED_BITWISE_TYPES.Contains(rightType.Name)))
+                    return;
+
+                Logger.CodegenWarning(node, "Using 128/64 bit integers when performing binary operations on Luau may result in undefined behaviour.");
+                WriteLine();
+                Write("--> rbxcsc warn: long/Int64 or Int128/UInt128 bit operations may lead to undefined behaviour (above this warning).");
+
                 return;
             }
 

--- a/RobloxCS/Constants.cs
+++ b/RobloxCS/Constants.cs
@@ -4,6 +4,14 @@ namespace RobloxCS
 {
     internal static class Constants
     {
+        public static readonly HashSet<string> UNSUPPORTED_BITWISE_TYPES =
+        [
+            "UInt128",
+            "ulong",
+            "long",
+            "Int128"
+        ];
+
         public static readonly HashSet<string> LENGTH_READABLE_TYPES =
         [
             "String",

--- a/RobloxCS/Constants.cs
+++ b/RobloxCS/Constants.cs
@@ -4,7 +4,8 @@ namespace RobloxCS
 {
     internal static class Constants
     {
-        public static readonly HashSet<string> LENGTH_READABLE_TYPES = [
+        public static readonly HashSet<string> LENGTH_READABLE_TYPES =
+        [
             "String",
             "string",
             "Array"
@@ -19,7 +20,8 @@ namespace RobloxCS
             { "Reverse", "reverse" }
         };
 
-        public static readonly HashSet<string> GLOBAL_LIBRARIES = [
+        public static readonly HashSet<string> GLOBAL_LIBRARIES =
+        [
             "task",
             "math",
             "table",
@@ -30,7 +32,8 @@ namespace RobloxCS
             "debug"
         ];
 
-        public static readonly HashSet<string> METAMETHODS = [
+        public static readonly HashSet<string> METAMETHODS =
+        [
             "__tostring",
             "__add",
             "__sub",
@@ -53,7 +56,8 @@ namespace RobloxCS
             "__metatable",
         ];
 
-        public static readonly HashSet<string> LUAU_KEYWORDS = [
+        public static readonly HashSet<string> LUAU_KEYWORDS =
+        [
             "local",
             "and",
             "or",
@@ -72,21 +76,24 @@ namespace RobloxCS
             "typeof"
         ];
 
-        public static readonly HashSet<SyntaxKind> MEMBER_PARENT_SYNTAXES = [
+        public static readonly HashSet<SyntaxKind> MEMBER_PARENT_SYNTAXES =
+        [
             SyntaxKind.NamespaceDeclaration,
             SyntaxKind.ClassDeclaration,
             SyntaxKind.InterfaceDeclaration,
             SyntaxKind.StructDeclaration
         ];
 
-        public static readonly HashSet<string> NO_FULL_QUALIFICATION_TYPES = [
+        public static readonly HashSet<string> NO_FULL_QUALIFICATION_TYPES =
+        [
             "System",
             "Roblox",
             "Globals",
             "PluginClasses"
         ];
 
-        public static readonly HashSet<string> IGNORED_BINARY_OPERATORS = [
+        public static readonly HashSet<string> IGNORED_BINARY_OPERATORS =
+        [
             "as"
         ];
 
@@ -95,14 +102,16 @@ namespace RobloxCS
             { ["String", "string"], ("+", "..") }
         };
 
-        public static readonly HashSet<string> DECIMAL_TYPES = [
+        public static readonly HashSet<string> DECIMAL_TYPES =
+        [
             "float",
             "double",
             "Single",
             "Double"
         ];
 
-        public static readonly HashSet<string> INTEGER_TYPES = [
+        public static readonly HashSet<string> INTEGER_TYPES =
+        [
             "sbyte",
             "byte",
             "short",

--- a/RobloxCS/Logger.cs
+++ b/RobloxCS/Logger.cs
@@ -31,6 +31,12 @@ namespace RobloxCS
             Error($"{message}\n\t- {Utility.FormatLocation(lineSpan)}");
         }
 
+        public static void CodegenWarning(SyntaxToken token, string message)
+        {
+            var lineSpan = token.GetLocation().GetLineSpan();
+            Warn($"{message}\n\t- {Utility.FormatLocation(lineSpan)}");
+        }
+
         public static void UnsupportedError(SyntaxNode node, string subject, bool? useIs = false)
         {
             CodegenError(node, $"{subject} {(useIs == true ? "is" : "are")} not yet supported, sorry!");
@@ -39,6 +45,11 @@ namespace RobloxCS
         public static void CodegenError(SyntaxNode node, string message)
         {
             CodegenError(node.GetFirstToken(), message);
+        }
+
+        public static void CodegenWarning(SyntaxNode node, string message)
+        {
+            CodegenWarning(node.GetFirstToken(), message);
         }
 
         public static void HandleDiagnostic(Diagnostic diagnostic)


### PR DESCRIPTION
Closes #9 

This pull requests adds a codegen warning and a comment into the generated code about unsupported integer types when doing binary operations. This pull request also encompasses 128 bit integers.