### PR TITLE
Disable the extern keyword. 

### DIFF
--- a/RobloxCS/CodeGenerator.cs
+++ b/RobloxCS/CodeGenerator.cs
@@ -1729,6 +1729,11 @@ namespace RobloxCS
             }
             foreach (var method in nonStaticMethods)
             {
+                if (HasSyntax(method.Modifiers, SyntaxKind.ExternKeyword))
+                {
+                    Logger.CodegenError(method, "extern methods are not supported.");
+                }
+
                 Visit(method);
             }
 

--- a/RobloxCS/README.md
+++ b/RobloxCS/README.md
@@ -19,8 +19,6 @@ This project includes the compiler and transformers.
 - Full qualification of types/namespaces inside of namespaces
 - Macro `new T()` with collection types to `{}`
 - `const` declarations
-- Disable `extern` keyword
-- `params` keyword
 - Config option for emitting `@native` on namespace/class callbacks
 
 ## Will maybe be supported


### PR DESCRIPTION
This pull request disables the usage of `extern`, and will error when attempting to transcompile C# code into Luau that uses it.