### PR TITLE
fix(nuget): package source mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vs/
+.idea/
+
 obj/
 bin/

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSourceMapping>
+    <packageSource key="rbxcs">
+      <package pattern="RobloxCS.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
small fix to allow support for users that have [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping) enabled.